### PR TITLE
Bugfix: Django redirect URL was hardcoded to "admin/hello"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-01-26
+
+### Fixed
+- Fixed hardcoded redirect URL in Django OAuth callback - now uses configurable `CIVIC_AUTH_SUCCESS_REDIRECT_URL` setting with default fallback to "/"
+
 ## [0.1.0] - 2025-01-26
 
 ### Added
@@ -30,4 +35,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Framework-agnostic core library
 - Optional framework dependencies
 
+[0.1.1]: https://github.com/civicteam/civic-auth-py/releases/tag/v0.1.1
 [0.1.0]: https://github.com/civicteam/civic-auth-py/releases/tag/v0.1.0

--- a/civic_auth/integrations/django.py
+++ b/civic_auth/integrations/django.py
@@ -233,7 +233,7 @@ def callback(request):
 
         # Get redirect URL from settings or default to home
         redirect_url = getattr(settings, 'CIVIC_AUTH_SUCCESS_REDIRECT_URL', '/')
-        
+
         # Create redirect response and apply cookies
         response = HttpResponseRedirect(redirect_url)
         if hasattr(request, "civic_storage"):

--- a/civic_auth/integrations/django.py
+++ b/civic_auth/integrations/django.py
@@ -232,7 +232,7 @@ def callback(request):
         run_async(auth.resolve_oauth_access_code(code, state))
 
         # Get redirect URL from settings or default to home
-        redirect_url = getattr(settings, 'CIVIC_AUTH_SUCCESS_REDIRECT_URL', '/')
+        redirect_url = getattr(settings, "CIVIC_AUTH_SUCCESS_REDIRECT_URL", "/")
 
         # Create redirect response and apply cookies
         response = HttpResponseRedirect(redirect_url)

--- a/civic_auth/integrations/django.py
+++ b/civic_auth/integrations/django.py
@@ -231,8 +231,11 @@ def callback(request):
     try:
         run_async(auth.resolve_oauth_access_code(code, state))
 
+        # Get redirect URL from settings or default to home
+        redirect_url = getattr(settings, 'CIVIC_AUTH_SUCCESS_REDIRECT_URL', '/')
+        
         # Create redirect response and apply cookies
-        response = HttpResponseRedirect("/admin/hello")
+        response = HttpResponseRedirect(redirect_url)
         if hasattr(request, "civic_storage"):
             request.civic_storage.apply_to_response(response)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "civic-auth"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for Civic Auth server-side authentication"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -1,6 +1,7 @@
 """Tests for Django integration."""
 
 import os
+from unittest.mock import AsyncMock, patch
 
 # Configure Django settings before importing Django modules
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.django_settings")
@@ -11,11 +12,12 @@ django.setup()
 
 # noqa imports below need to come after django.setup()
 from django.http import HttpResponse  # noqa: E402
-from django.test import RequestFactory  # noqa: E402
+from django.test import RequestFactory, override_settings  # noqa: E402
 
 from civic_auth.integrations.django import (  # noqa: E402
     CivicAuthMiddleware,
     DjangoCookieStorage,
+    callback,
     civic_auth_required,
     get_auth_urls,
 )
@@ -84,3 +86,106 @@ class TestDjangoIntegration:
         response = protected_view(request)
         assert response.status_code == 401
         assert response.content == b"Unauthorized"
+
+    @patch("civic_auth.integrations.django.run_async")
+    def test_callback_default_redirect(self, mock_run_async):
+        """Test callback redirects to default '/' when no custom redirect URL is set."""
+        from civic_auth import CivicAuth
+
+        # Mock the async auth operations
+        mock_run_async.return_value = None
+
+        factory = RequestFactory()
+        request = factory.get("/auth/callback?code=test-code&state=test-state")
+
+        # Add middleware attributes to simulate middleware running
+        config = {
+            "client_id": "test-client-id",
+            "redirect_url": "http://localhost:8000/auth/callback",
+        }
+        request.civic_storage = DjangoCookieStorage(request)
+        request.civic_auth = CivicAuth(request.civic_storage, config)
+
+        response = callback(request)
+
+        # Should redirect to default "/"
+        assert response.status_code == 302
+        assert response.url == "/"
+
+    @override_settings(CIVIC_AUTH_SUCCESS_REDIRECT_URL="/dashboard")
+    @patch("civic_auth.integrations.django.run_async")
+    def test_callback_custom_redirect(self, mock_run_async):
+        """Test callback redirects to custom URL when CIVIC_AUTH_SUCCESS_REDIRECT_URL is set."""
+        from civic_auth import CivicAuth
+
+        # Mock the async auth operations
+        mock_run_async.return_value = None
+
+        factory = RequestFactory()
+        request = factory.get("/auth/callback?code=test-code&state=test-state")
+
+        # Add middleware attributes to simulate middleware running
+        config = {
+            "client_id": "test-client-id",
+            "redirect_url": "http://localhost:8000/auth/callback",
+        }
+        request.civic_storage = DjangoCookieStorage(request)
+        request.civic_auth = CivicAuth(request.civic_storage, config)
+
+        response = callback(request)
+
+        # Should redirect to custom URL
+        assert response.status_code == 302
+        assert response.url == "/dashboard"
+
+    def test_callback_missing_parameters(self):
+        """Test callback returns 400 when code or state parameters are missing."""
+        from civic_auth import CivicAuth
+
+        factory = RequestFactory()
+
+        # Test missing code
+        request = factory.get("/auth/callback?state=test-state")
+        config = {
+            "client_id": "test-client-id",
+            "redirect_url": "http://localhost:8000/auth/callback",
+        }
+        request.civic_storage = DjangoCookieStorage(request)
+        request.civic_auth = CivicAuth(request.civic_storage, config)
+
+        response = callback(request)
+        assert response.status_code == 400
+        assert "Missing code or state parameter" in response.content.decode()
+
+        # Test missing state
+        request = factory.get("/auth/callback?code=test-code")
+        request.civic_storage = DjangoCookieStorage(request)
+        request.civic_auth = CivicAuth(request.civic_storage, config)
+
+        response = callback(request)
+        assert response.status_code == 400
+        assert "Missing code or state parameter" in response.content.decode()
+
+    @patch("civic_auth.integrations.django.run_async")
+    def test_callback_auth_failure(self, mock_run_async):
+        """Test callback returns 400 when authentication fails."""
+        from civic_auth import CivicAuth
+
+        # Mock auth failure
+        mock_run_async.side_effect = Exception("Auth failed")
+
+        factory = RequestFactory()
+        request = factory.get("/auth/callback?code=test-code&state=test-state")
+
+        config = {
+            "client_id": "test-client-id",
+            "redirect_url": "http://localhost:8000/auth/callback",
+        }
+        request.civic_storage = DjangoCookieStorage(request)
+        request.civic_auth = CivicAuth(request.civic_storage, config)
+
+        response = callback(request)
+
+        # Should return 400 with error message
+        assert response.status_code == 400
+        assert "Auth failed: Auth failed" in response.content.decode()

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -1,7 +1,7 @@
 """Tests for Django integration."""
 
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 # Configure Django settings before importing Django modules
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.django_settings")


### PR DESCRIPTION
The redirect URL was hardcoded to "admin/hello" in the Django integration. This was causing issues when the user was redirected back to the application after logging in.

This commit fixes the issue by using the configurable `CIVIC_AUTH_SUCCESS_REDIRECT_URL` setting with default fallback to "/".